### PR TITLE
Implement phase 1 skeleton

### DIFF
--- a/src/main/java/studio/joaosouza/bibleMinigames/BibleMinigames.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/BibleMinigames.java
@@ -1,17 +1,44 @@
 package studio.joaosouza.bibleMinigames;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import studio.joaosouza.bibleMinigames.commands.BMACommand;
+import studio.joaosouza.bibleMinigames.commands.BMCommand;
+import studio.joaosouza.bibleMinigames.core.ArenaManager;
+import studio.joaosouza.bibleMinigames.core.ConfigManager;
+import studio.joaosouza.bibleMinigames.core.GameManager;
+import studio.joaosouza.bibleMinigames.minigames.DavidAndGoliathMinigame;
 
+/**
+ * Main plugin class.
+ */
 public final class BibleMinigames extends JavaPlugin {
+
+    private ConfigManager configManager;
+    private GameManager gameManager;
+    private ArenaManager arenaManager;
 
     @Override
     public void onEnable() {
-        System.out.println("Plugin enabled");
+        this.configManager = new ConfigManager(this);
+        this.arenaManager = new ArenaManager(this);
+        this.gameManager = new GameManager();
 
+        // register default game
+        gameManager.registerGame(new DavidAndGoliathMinigame(this));
+
+        getCommand("bm").setExecutor(new BMCommand(gameManager));
+        getCommand("bma").setExecutor(new BMACommand(arenaManager));
+
+        getLogger().info("BibleMinigames enabled");
     }
 
     @Override
     public void onDisable() {
-        System.out.println("Plugin disabled");
+        arenaManager.save();
+        getLogger().info("BibleMinigames disabled");
+    }
+
+    public GameManager getGameManager() {
+        return gameManager;
     }
 }

--- a/src/main/java/studio/joaosouza/bibleMinigames/commands/BMACommand.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/commands/BMACommand.java
@@ -1,0 +1,43 @@
+package studio.joaosouza.bibleMinigames.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import studio.joaosouza.bibleMinigames.core.ArenaManager;
+
+/**
+ * Simple admin command handler.
+ */
+public class BMACommand implements CommandExecutor {
+
+    private final ArenaManager arenaManager;
+
+    public BMACommand(ArenaManager manager) {
+        this.arenaManager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (args.length == 0) {
+            player.sendMessage(ChatColor.YELLOW + "/bma tool | reload");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("tool")) {
+            player.getInventory().addItem(new ItemStack(Material.BLAZE_ROD));
+            player.sendMessage(ChatColor.GREEN + "Varita entregada");
+        } else if (args[0].equalsIgnoreCase("reload")) {
+            arenaManager.save();
+            player.sendMessage(ChatColor.GREEN + "Configuración guardada");
+        }
+        return true;
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/commands/BMCommand.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/commands/BMCommand.java
@@ -1,0 +1,42 @@
+package studio.joaosouza.bibleMinigames.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import studio.joaosouza.bibleMinigames.core.GameManager;
+
+/**
+ * Command for players to interact with minigames.
+ */
+public class BMCommand implements CommandExecutor {
+
+    private final GameManager gameManager;
+
+    public BMCommand(GameManager manager) {
+        this.gameManager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (args.length == 0) {
+            player.sendMessage(ChatColor.YELLOW + "/bm join <game>");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("join") && args.length >= 2) {
+            gameManager.joinGame(player, args[1]);
+            player.sendMessage(ChatColor.GREEN + "Joined game " + args[1]);
+        } else if (args[0].equalsIgnoreCase("leave")) {
+            player.sendMessage(ChatColor.RED + "Leaving game is not implemented yet.");
+        } else if (args[0].equalsIgnoreCase("list")) {
+            player.sendMessage(ChatColor.YELLOW + "Games: " + gameManager.getGame("david_goliath").getId());
+        }
+        return true;
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/core/ArenaManager.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/core/ArenaManager.java
@@ -1,0 +1,83 @@
+package studio.joaosouza.bibleMinigames.core;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Loads and manages arena configurations.
+ */
+public class ArenaManager {
+
+    private final Set<String> arenas = new HashSet<>();
+    private final File arenasFile;
+    private final FileConfiguration config;
+    private final JavaPlugin plugin;
+
+    public ArenaManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.arenasFile = new File(plugin.getDataFolder(), "arenas.yml");
+        if (!arenasFile.exists()) {
+            plugin.saveResource("arenas.yml", false);
+        }
+        this.config = YamlConfiguration.loadConfiguration(arenasFile);
+        setupWorld();
+        copyDefaultSchematics();
+        createDefaultArenaEntries();
+        arenas.addAll(config.getConfigurationSection("arenas").getKeys(false));
+    }
+
+    public Set<String> getArenas() {
+        return arenas;
+    }
+
+    public void save() {
+        try {
+            config.save(arenasFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void setupWorld() {
+        World world = Bukkit.getWorld("bible_minigames_world");
+        if (world == null) {
+            WorldCreator creator = new WorldCreator("bible_minigames_world");
+            creator.generator(new VoidWorldGenerator());
+            world = Bukkit.createWorld(creator);
+            if (world != null) {
+                world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, false);
+                world.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
+            }
+        }
+    }
+
+    private void copyDefaultSchematics() {
+        File schemDir = new File(plugin.getDataFolder(), "schematics");
+        if (!schemDir.exists()) {
+            schemDir.mkdirs();
+        }
+        File dg = new File(schemDir, "david_goliath_default.schem");
+        if (!dg.exists()) {
+            plugin.saveResource("schematics/david_goliath_default.schem", false);
+        }
+    }
+
+    private void createDefaultArenaEntries() {
+        String path = "arenas.david_goliath_default";
+        if (!config.contains(path)) {
+            config.set(path + ".type", "DEFAULT");
+            config.set(path + ".game_type", "DAVID_GOLIATH");
+            config.set(path + ".enabled", true);
+        }
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/core/ConfigManager.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/core/ConfigManager.java
@@ -1,0 +1,34 @@
+package studio.joaosouza.bibleMinigames.core;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+
+/**
+ * Manages configuration files.
+ */
+public class ConfigManager {
+
+    private final JavaPlugin plugin;
+    private FileConfiguration messages;
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        plugin.saveDefaultConfig();
+        loadMessages();
+    }
+
+    private void loadMessages() {
+        File messagesFile = new File(plugin.getDataFolder(), "messages.yml");
+        if (!messagesFile.exists()) {
+            plugin.saveResource("messages.yml", false);
+        }
+        messages = YamlConfiguration.loadConfiguration(messagesFile);
+    }
+
+    public FileConfiguration getMessages() {
+        return messages;
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/core/GameManager.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/core/GameManager.java
@@ -1,0 +1,32 @@
+package studio.joaosouza.bibleMinigames.core;
+
+import org.bukkit.entity.Player;
+import studio.joaosouza.bibleMinigames.minigames.AbstractMinigame;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles running minigames and their lifecycle.
+ */
+public class GameManager {
+
+    private final Map<String, AbstractMinigame> games = new HashMap<>();
+
+    public void registerGame(AbstractMinigame game) {
+        games.put(game.getId().toLowerCase(), game);
+    }
+
+    public AbstractMinigame getGame(String id) {
+        return games.get(id.toLowerCase());
+    }
+
+    public void joinGame(Player player, String id) {
+        AbstractMinigame game = games.get(id.toLowerCase());
+        if (game != null) {
+            game.addPlayer(player);
+            if (game.getState() == studio.joaosouza.bibleMinigames.minigames.GameState.WAITING) {
+                game.start();
+            }
+        }
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/core/VoidWorldGenerator.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/core/VoidWorldGenerator.java
@@ -1,0 +1,18 @@
+package studio.joaosouza.bibleMinigames.core;
+
+import org.bukkit.World;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.ChunkGenerator.ChunkData;
+import org.bukkit.generator.ChunkGenerator.BiomeGrid;
+
+import java.util.Random;
+
+/**
+ * Simple generator that creates an empty world.
+ */
+public class VoidWorldGenerator extends ChunkGenerator {
+    @Override
+    public ChunkData generateChunkData(World world, Random random, int chunkX, int chunkZ, BiomeGrid biome) {
+        return createChunkData(world);
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/minigames/AbstractMinigame.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/minigames/AbstractMinigame.java
@@ -1,0 +1,49 @@
+package studio.joaosouza.bibleMinigames.minigames;
+
+import org.bukkit.entity.Player;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Basic structure for all minigames.
+ */
+public abstract class AbstractMinigame {
+
+    private final Set<Player> players = new HashSet<>();
+    private GameState state = GameState.WAITING;
+
+    /**
+     * @return unique identifier for the game
+     */
+    public abstract String getId();
+
+    public GameState getState() {
+        return state;
+    }
+
+    protected void setState(GameState state) {
+        this.state = state;
+    }
+
+    public Set<Player> getPlayers() {
+        return players;
+    }
+
+    public void addPlayer(Player player) {
+        players.add(player);
+    }
+
+    public void removePlayer(Player player) {
+        players.remove(player);
+    }
+
+    /**
+     * Called when the game should start.
+     */
+    public abstract void start();
+
+    /**
+     * Called when the game should end.
+     */
+    public abstract void end();
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/minigames/DavidAndGoliathMinigame.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/minigames/DavidAndGoliathMinigame.java
@@ -1,0 +1,59 @@
+package studio.joaosouza.bibleMinigames.minigames;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Giant;
+import org.bukkit.entity.EntityType;
+import org.bukkit.scheduler.BukkitTask;
+import studio.joaosouza.bibleMinigames.BibleMinigames;
+
+/**
+ * Simplified implementation of the David vs Goliath minigame.
+ */
+public class DavidAndGoliathMinigame extends AbstractMinigame {
+
+    private final BibleMinigames plugin;
+    private Giant goliath;
+    private BukkitTask task;
+
+    public DavidAndGoliathMinigame(BibleMinigames plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getId() {
+        return "david_goliath";
+    }
+
+    @Override
+    public void start() {
+        setState(GameState.LIVE);
+        for (Player p : getPlayers()) {
+            p.sendMessage(ChatColor.GOLD + "¡Derrota a Goliat!");
+        }
+        // Spawn a simple giant as Goliath
+        goliath = (Giant) getPlayers().iterator().next().getWorld().spawnEntity(getPlayers().iterator().next().getLocation(), EntityType.GIANT);
+        task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+            if (goliath.isDead()) {
+                end();
+            }
+        }, 20L, 20L);
+    }
+
+    @Override
+    public void end() {
+        setState(GameState.ENDING);
+        if (goliath != null && !goliath.isDead()) {
+            goliath.remove();
+        }
+        if (task != null) {
+            task.cancel();
+        }
+        for (Player p : getPlayers()) {
+            p.sendMessage(ChatColor.GREEN + "Con fe, el más pequeño puede vencer al más grande.");
+        }
+        getPlayers().clear();
+        setState(GameState.WAITING);
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/minigames/GameState.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/minigames/GameState.java
@@ -1,0 +1,12 @@
+package studio.joaosouza.bibleMinigames.minigames;
+
+/**
+ * Represents the current state of a minigame.
+ */
+public enum GameState {
+    REGENERATING,
+    WAITING,
+    COUNTDOWN,
+    LIVE,
+    ENDING
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/player/PlayerProfile.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/player/PlayerProfile.java
@@ -1,0 +1,37 @@
+package studio.joaosouza.bibleMinigames.player;
+
+import java.util.UUID;
+
+/**
+ * Data container for player progress.
+ */
+public class PlayerProfile {
+    private final UUID uuid;
+    private String lastKnownName;
+    private int faithPoints;
+
+    public PlayerProfile(UUID uuid, String name) {
+        this.uuid = uuid;
+        this.lastKnownName = name;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public String getLastKnownName() {
+        return lastKnownName;
+    }
+
+    public void setLastKnownName(String lastKnownName) {
+        this.lastKnownName = lastKnownName;
+    }
+
+    public int getFaithPoints() {
+        return faithPoints;
+    }
+
+    public void addFaithPoints(int amount) {
+        faithPoints += amount;
+    }
+}

--- a/src/main/java/studio/joaosouza/bibleMinigames/player/ProfileManager.java
+++ b/src/main/java/studio/joaosouza/bibleMinigames/player/ProfileManager.java
@@ -1,0 +1,19 @@
+package studio.joaosouza.bibleMinigames.player;
+
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages the profiles of online players.
+ */
+public class ProfileManager {
+
+    private final Map<UUID, PlayerProfile> profiles = new HashMap<>();
+
+    public PlayerProfile getProfile(Player player) {
+        return profiles.computeIfAbsent(player.getUniqueId(), uuid -> new PlayerProfile(uuid, player.getName()));
+    }
+}

--- a/src/main/resources/arenas.yml
+++ b/src/main/resources/arenas.yml
@@ -1,0 +1,5 @@
+arenas:
+  david_goliath_default:
+    type: DEFAULT
+    game_type: DAVID_GOLIATH
+    enabled: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+prefix: "&6[BibleMinigames] &r"
+storage:
+  type: SQLite

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,1 @@
+game-join-success: "%prefix% &aTe has unido a &e%game%&a."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,5 +3,11 @@ version: '1.0-SNAPSHOT'
 main: studio.joaosouza.bibleMinigames.BibleMinigames
 api-version: '1.21'
 authors: [ ImJoaoSouza ]
-description: Plugin
+description: Minigames basados en historias de la Biblia
 website: https://joaosouza.studio
+
+commands:
+  bm:
+    description: Comandos de usuario para BibleMinigames
+  bma:
+    description: Comandos administrativos de BibleMinigames

--- a/src/main/resources/schematics/david_goliath_default.schem
+++ b/src/main/resources/schematics/david_goliath_default.schem
@@ -1,0 +1,1 @@
+Placeholder schematic


### PR DESCRIPTION
## Summary
- create skeleton code for arena and game management
- implement simple David vs Goliath minigame
- add player profile management
- add basic commands `/bm` and `/bma`
- ship default config files
- handle default world generation and schematic extraction

## Testing
- `mvn -q package` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68547ec8b3a483288eddf4e49a208a2e